### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # see travis-ci.org for details
 
 language: csharp
-mono: 4.6.1
+mono: 6.4.0
 sudo: false
 
 addons:


### PR DESCRIPTION
Travis failed the last PR build, so hoping this will fix it (changes version to be consistent with upstream OpenRA bleed travis.yaml)